### PR TITLE
Add admin login endpoint and authentication module

### DIFF
--- a/src/admin_auth.py
+++ b/src/admin_auth.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+def load_admins():
+    admins_path = Path(__file__).parent / "admins.json"
+    if admins_path.exists():
+        with open(admins_path, "r") as f:
+            return json.load(f)
+    return {}
+
+def authenticate_admin(username, password):
+    admins = load_admins()
+    return admins.get(username) == password

--- a/src/admins.json
+++ b/src/admins.json
@@ -1,0 +1,4 @@
+{
+  "teacher1": "password123",
+  "teacher2": "securepass456"
+}

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,20 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Form
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from admin_auth import authenticate_admin
+from fastapi import status
+from fastapi.responses import JSONResponse
+@app.post("/admin/login")
+def admin_login(username: str = Form(...), password: str = Form(...)):
+    """Authenticate admin user."""
+    if authenticate_admin(username, password):
+        return {"message": f"Welcome, {username}. Login successful.", "admin": True}
+    return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content={"detail": "Invalid credentials"})
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")


### PR DESCRIPTION
This pull request implements an administrator login endpoint and authentication module. It adds:
- `/admin/login` endpoint for admin authentication
- `admin_auth.py` for credential checking
- `admins.json` for storing teacher usernames and passwords

This is the first step toward supporting multi-user roles and secure admin management of chapters and activities.